### PR TITLE
[fix]add socket: to database.yml

### DIFF
--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -16,6 +16,7 @@ default: &default
   username: root
   password: password
   host: db
+  socket: /tmp/myapp.sock
 
 development:
   <<: *default


### PR DESCRIPTION
`git clone`だけでは`docker-compose run --rm api rails db:create`が通らなかったため、
database.ymlに`socket: /tmp/myapp.sock`を追加した。
socketを追記することで`docker-compose run --rm api rails db:create`が通るようになった。