### PR TITLE
[add]Headerの作成(issue32)

### DIFF
--- a/react_view/react-project/react-sample/src/App.css
+++ b/react_view/react-project/react-sample/src/App.css
@@ -36,3 +36,7 @@
     transform: rotate(360deg);
   }
 }
+
+body {
+  padding-top: 5%;
+}

--- a/react_view/react-project/react-sample/src/App.js
+++ b/react_view/react-project/react-sample/src/App.js
@@ -1,23 +1,20 @@
-import logo from './logo.svg';
+import React, { useEffect, useRef, useState } from "react";
 import './App.css';
+import CenteredTabs from './pages/CenteredTabs.js';
+import Header from './components/Header.js'
+import Title from './pages/Title.js'
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <Header className="App-header" />
+      <body>
+        <Title />
+        <CenteredTabs labels={['students', 'Teachers']}>
+          <div>aa</div>
+          <div>bb</div>
+        </CenteredTabs>
+      </body>
     </div>
   );
 }

--- a/react_view/react-project/react-sample/src/App.js
+++ b/react_view/react-project/react-sample/src/App.js
@@ -1,6 +1,9 @@
 import React, { useEffect, useRef, useState } from "react";
+import { Grid } from '@material-ui/core';
 import './App.css';
 import CenteredTabs from './pages/CenteredTabs.js';
+import StudentsTable from './pages/StudentsTable.js';
+import TeachersTable from './pages/TeachersTable.js';
 import Header from './components/Header.js'
 import Title from './pages/Title.js'
 
@@ -9,11 +12,15 @@ function App() {
     <div className="App">
       <Header className="App-header" />
       <body>
-        <Title />
-        <CenteredTabs labels={['students', 'Teachers']}>
-          <div>aa</div>
-          <div>bb</div>
-        </CenteredTabs>
+        <Grid container alignItems="center" justify="center">
+          <Grid item xs={8}>
+            <Title />
+            <CenteredTabs labels={['Students', 'Teachers']}>
+              <StudentsTable />
+              <TeachersTable />
+            </CenteredTabs>
+          </Grid>
+        </Grid>
       </body>
     </div>
   );

--- a/react_view/react-project/react-sample/src/components/Header.js
+++ b/react_view/react-project/react-sample/src/components/Header.js
@@ -1,0 +1,28 @@
+import { AppBar, Button, Toolbar, Typography, makeStyles } from '@material-ui/core'
+import React from 'react'
+import AccountCircleIcon from '@material-ui/icons/AccountCircle'
+
+const useStyles = makeStyles(() => ({
+  typographyStyles: {
+    flex: 2
+  }
+}));
+
+function Header(headerRef) {
+  const classes = useStyles();
+  return (
+    <header>
+      <AppBar positon="fixed">
+			  <Toolbar>
+				  <Typography className={classes.typographyStyles} variant="h5">
+            NUTFES RECORD
+          </Typography>
+          <AccountCircleIcon />
+          <Button color="inherit">Login</Button>
+			  </Toolbar>
+      </AppBar>
+    </header>
+  )
+}
+
+export default Header

--- a/react_view/react-project/react-sample/src/index.js
+++ b/react_view/react-project/react-sample/src/index.js
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App.js';
 import reportWebVitals from './reportWebVitals';
 
+
 // index.htmlの"id=root"にAppコンポーネントを描画する 
 ReactDOM.render(
   <React.StrictMode>

--- a/react_view/react-project/react-sample/src/pages/CenteredTabs.js
+++ b/react_view/react-project/react-sample/src/pages/CenteredTabs.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import Box from '@material-ui/core/Box';
+
+
+const useStyles = makeStyles({
+  root: {
+    flexGrow: 1,
+  },
+});
+
+// 追加
+const TabPanel = (props) => {
+    const { children, value, index, ...other } = props;
+
+    return (
+      <div
+        role="tabpanel"
+        hidden={value !== index}
+        id={`simple-tabpanel-${index}`}
+        aria-labelledby={`simple-tab-${index}`}
+        {...other}
+      >
+        {value === index && (
+          <Box p={3}>
+            {children}
+          </Box>
+        )}
+      </div>
+    );
+}
+
+
+const CenteredTabs = (props) => {
+  const classes = useStyles();
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  return (
+    <div>
+        <Paper className={classes.root}>
+            <Tabs
+                value={value}
+                onChange={handleChange}
+                indicatorColor="primary"
+                textColor="primary"
+                centered
+            >
+                {props.labels.map(label => <Tab label={label}></Tab>)} {/* さっきの */}
+            </Tabs>
+        </Paper>
+
+        {/* 公式ドキュメントの各タブのコンテンツ
+        <TabPanel value={value} index={0}>
+            Item One
+        </TabPanel>
+        <TabPanel value={value} index={1}>
+            Item Two
+        </TabPanel>
+        <TabPanel value={value} index={2}>
+            Item Three
+        </TabPanel>
+        */}
+
+        {/* 追加 */}
+        {props.children.map((child, index) => 
+            <TabPanel value={value} index={index}>{child}</TabPanel>)
+        }
+    </div>
+  );
+}
+
+export default CenteredTabs

--- a/react_view/react-project/react-sample/src/pages/StudentsTable.js
+++ b/react_view/react-project/react-sample/src/pages/StudentsTable.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+
+const useStyles = makeStyles({
+  table: {
+    minWidth: 650,
+  },
+});
+
+function createData(role, name) {
+  return { role, name };
+}
+
+const rows = [
+  createData('student', '藤崎竜成'),
+  createData('student', '小林諒太'),
+  createData('student', '安田巴'),
+];
+
+export default function DenseTable() {
+  const classes = useStyles();
+
+  return (
+    <TableContainer component={Paper}>
+      <Table className={classes.table} size="small" aria-label="a dense table">
+        <TableHead>
+          <TableRow>
+            <TableCell>Role</TableCell>
+            <TableCell>Name</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.role}>
+              <TableCell component="th" scope="row">
+                {row.role}
+              </TableCell>
+              <TableCell>{row.name}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/react_view/react-project/react-sample/src/pages/TeachersTable.js
+++ b/react_view/react-project/react-sample/src/pages/TeachersTable.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+
+const useStyles = makeStyles({
+  table: {
+    minWidth: 650,
+  },
+});
+
+function createData(role, name) {
+  return { role, name };
+}
+
+const rows = [
+  createData('teacher', '大場雅士'),
+  createData('teacher', '百々優志郎'),
+  createData('teacher', '久々江耀平'),
+];
+
+export default function DenseTable() {
+  const classes = useStyles();
+
+  return (
+    <TableContainer component={Paper}>
+      <Table className={classes.table} size="small" aria-label="a dense table">
+        <TableHead>
+          <TableRow>
+            <TableCell>Role</TableCell>
+            <TableCell>Name</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.role}>
+              <TableCell component="th" scope="row">
+                {row.role}
+              </TableCell>
+              <TableCell>{row.name}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/react_view/react-project/react-sample/src/pages/Title.js
+++ b/react_view/react-project/react-sample/src/pages/Title.js
@@ -1,0 +1,12 @@
+import { Typography } from '@material-ui/core'
+import React from 'react'
+
+function Title() {
+  return (
+		<Typography variant="h5">
+      Members
+    </Typography>
+  )
+}
+
+export default Title


### PR DESCRIPTION
ヘッダーが表示されるように、ヘッダーの作成を行った。
その他のコンテンツに関しては適当に記述している。（下の画像参照）

通常だとヘッダーとコンテンツが重複していてｍコンテンツが見えなかったため、
App.cssにpaddingを適当に設定した。

![image](https://user-images.githubusercontent.com/71711872/117531938-f670e280-b01f-11eb-9f2b-b5851b6c6178.png)
